### PR TITLE
Get rid of GL errors from ScopedDepth

### DIFF
--- a/NanoguiModule/nanogui/screen.cpp
+++ b/NanoguiModule/nanogui/screen.cpp
@@ -50,7 +50,7 @@ void Screen::drawWidgets()
    ci::gl::ScopedVao scopedVao (nullptr);
    ci::gl::ScopedTextureBind text2 (GL_TEXTURE_2D, 0);
    ci::gl::ScopedTextureBind text3(GL_TEXTURE_3D, 0);
-   ci::gl::ScopedDepth depth(false, false);  // FIXME causes GL errors
+   ci::gl::ScopedDepth depth(false, GL_LESS);
 
    nvgEndFrame (mNVGContext);
 }


### PR DESCRIPTION
The `depthFunc` second argument to the `gl::ScopedDepth` constructor isn't a bool, it's a `GLenum`, so you need to give it a valid value, such as GL_LESS, GL_ALWAYS, GL_NEVER, etc.
